### PR TITLE
removed a bug due to multiple exec modes

### DIFF
--- a/EclipseWork/SCAIEV/src/scaiev/SCAIEV.java
+++ b/EclipseWork/SCAIEV/src/scaiev/SCAIEV.java
@@ -273,8 +273,8 @@ public class SCAIEV {
 		BNodes.WrRD.commitStage = core.maxStage;
 		for(SCAIEVNode nodeAdj : BNodes.GetAdjSCAIEVNodes(BNode.WrRD))
 			nodeAdj.commitStage = core.maxStage;
-		BNodes.WrPC.commitStage = core.maxStage;	
-		BNodes.WrPC_valid.commitStage =  core.maxStage;
+		BNodes.WrPC.commitStage = core.GetNodes().get(BNode.WrPC).GetEarliest(); // risky: was core.maxStage; Updated it so that always wrpc would be mapped to 0 when nodeStage=100 in automatic demo class	
+		BNodes.WrPC_valid.commitStage =  core.GetNodes().get(BNode.WrPC).GetEarliest();
 		
 		// Add commit stage info of WrUser node. First write nodes, than read nodes 
 		for(SCAIEVNode node : this.BNodes.GetAllBackNodes()) {

--- a/EclipseWork/SCAIEV/src/scaiev/frontend/SCAIEVInstr.java
+++ b/EclipseWork/SCAIEV/src/scaiev/frontend/SCAIEVInstr.java
@@ -94,7 +94,7 @@ public class SCAIEVInstr {
 			if(node.isSpawn() && !node.isAdj() && isSpawn) { // If we look at a main spawn node & the user wants this spawn operation (>=spawnStage)
 				Scheduled oldSched = new Scheduled();
 				oldSched = GetCheckUniqueSchedWith(parentNode, snode -> snode.GetStartCycle()>=spawnStage);
-				// This is no spawn in traditional (scaiev trad) sense, it's an instruction that writes right away based on its valid bit. Not really started by an opcode
+				// This is no spawn in traditional (scaiev trad) sense, it's an instruction that writes right away based on its valid bit. Not really started by an opcode. Always block
 				if(this.HasNoOp()) {
 					oldSched.UpdateStartCycle(parentNode.commitStage); // for write nodes, take the WB stage of that node // for read nodes, take the "read regfile" stage
 				} else if(node.isInput | (node==BNode.RdMem_spawn) ){ // spawn for reading state not supported for the moment. Just for write nodes. Or spawn as instr without decoding,which is actually mapped on read stage

--- a/EclipseWork/SCAIEV/src/scaiev/test/AutomaticDemoTest.java
+++ b/EclipseWork/SCAIEV/src/scaiev/test/AutomaticDemoTest.java
@@ -26,6 +26,7 @@ import scaiev.frontend.SCAIEVNode.AdjacentNode;
 public class AutomaticDemoTest {
 	public static HashMap<String, Integer> earliest_operation = new HashMap<String, Integer>();
 	
+	//TODO mem for always for cores which req in earlier, make sure default is 0 if no instru with opode
 	
 	public static void main(String[] args) {
 		//////////   SETTINGS   //////////
@@ -137,7 +138,7 @@ public class AutomaticDemoTest {
 										nodeStage = (int) readNode.get(nodeSetting);
 									}
 									if(is_always) // For read/writes without opcode: now set as spawn without decoding; in scaiev mapped on Read stage /WB stage; are direct read/writes
-										if( FNode.GetSCAIEVNode(nodeName)==null | (FNode.GetSCAIEVNode(nodeName)!=null && FNode.GetSCAIEVNode(nodeName).DH))
+										if( FNode.GetSCAIEVNode(nodeName)==null | (FNode.GetSCAIEVNode(nodeName)!=null ))
 											nodeStage = 10000; // immediate write
 								}
 								


### PR DESCRIPTION
After adding new exec modes, some other older broke (always). Fixed it. 
Now: all always nodes are mapped to stage = 1000 (spawn) in automatic demo. They are then moved to commit node stage in SCAIE-V Instruction class (convert to backend step in SCAIE-V class)